### PR TITLE
Add GeminiService tests

### DIFF
--- a/lib/core/services/gemini_service.dart
+++ b/lib/core/services/gemini_service.dart
@@ -4,8 +4,14 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 
 class GeminiService {
   late final GenerativeModel _model;
+  Future<GenerateContentResponse> Function(List<Content>)? generateContentOverride;
 
-  GeminiService() {
+  GeminiService({GenerativeModel? model, this.generateContentOverride}) {
+    if (model != null) {
+      _model = model;
+      return;
+    }
+
     final apiKey = dotenv.env['GEMINI_API_KEY'];
     if (apiKey == null) throw Exception('Gemini API Key không tìm thấy');
     _model = GenerativeModel(
@@ -20,6 +26,9 @@ class GeminiService {
 
   Future<GenerateContentResponse> generateContent(List<Content> content) async {
     try {
+      if (generateContentOverride != null) {
+        return await generateContentOverride!(content);
+      }
       return await _model.generateContent(content);
     } catch (e) {
       throw Exception('Failed to generate content from Gemini API: $e');
@@ -43,7 +52,9 @@ class GeminiService {
 
     String? rawText;
     try {
-      final response = await _model.generateContent([Content.text(prompt)]);
+      final response = await (generateContentOverride != null
+          ? generateContentOverride!([Content.text(prompt)])
+          : _model.generateContent([Content.text(prompt)]));
       rawText = response.text?.trim() ?? '{}';
 
       // Xử lý phản hồi để loại bỏ Markdown (nếu có)
@@ -73,7 +84,9 @@ class GeminiService {
 
     String? rawText;
     try {
-      final response = await _model.generateContent([Content.text(prompt)]);
+      final response = await (generateContentOverride != null
+          ? generateContentOverride!([Content.text(prompt)])
+          : _model.generateContent([Content.text(prompt)]));
       rawText = response.text?.trim() ?? '[]';
       rawText = rawText.replaceAll(RegExp(r'[^\x00-\x7F]+'), '');
       // Xử lý JSON an toàn
@@ -98,7 +111,9 @@ class GeminiService {
 
     String? rawText;
     try {
-      final response = await _model.generateContent([Content.text(prompt)]);
+      final response = await (generateContentOverride != null
+          ? generateContentOverride!([Content.text(prompt)])
+          : _model.generateContent([Content.text(prompt)]));
       rawText = response.text?.trim() ?? 'Planned';
       return rawText;
     } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.4.13
   hive_generator: ^2.0.1
+  mocktail: ^1.0.0
 
 flutter:
   assets:

--- a/test/core/services/gemini_service_test.dart
+++ b/test/core/services/gemini_service_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:moji_todo/core/services/gemini_service.dart';
+
+class MockGenerativeModel extends Mock implements GenerativeModel {}
+
+class FakeGenerateContentResponse extends Fake implements GenerateContentResponse {
+  FakeGenerateContentResponse(this._text);
+  final String _text;
+  @override
+  String? get text => _text;
+}
+
+void main() {
+  group('GeminiService', () {
+    late MockGenerativeModel mockModel;
+    late GeminiService service;
+
+    setUp(() {
+      mockModel = MockGenerativeModel();
+      service = GeminiService(model: mockModel);
+    });
+
+    group('parseUserCommand', () {
+      test('parses valid JSON', () async {
+        when(() => mockModel.generateContent(any())).thenAnswer(
+          (_) async => FakeGenerateContentResponse('{"type":"task"}'),
+        );
+
+        final result = await service.parseUserCommand('input');
+        expect(result, {'type': 'task'});
+      });
+
+      test('handles errors', () async {
+        when(() => mockModel.generateContent(any())).thenThrow(Exception('fail'));
+
+        final result = await service.parseUserCommand('input');
+        expect(result, {'error': 'Không thể phân tích câu lệnh từ Gemini API'});
+      });
+    });
+
+    group('getSmartSuggestions', () {
+      test('parses list JSON', () async {
+        when(() => mockModel.generateContent(any())).thenAnswer(
+          (_) async => FakeGenerateContentResponse('["a","b"]'),
+        );
+
+        final result = await service.getSmartSuggestions('ctx');
+        expect(result, ['a', 'b']);
+      });
+
+      test('handles errors', () async {
+        when(() => mockModel.generateContent(any())).thenThrow(Exception('fail'));
+
+        final result = await service.getSmartSuggestions('ctx');
+        expect(result, isEmpty);
+      });
+    });
+
+    group('classifyTask', () {
+      test('returns classification', () async {
+        when(() => mockModel.generateContent(any())).thenAnswer(
+          (_) async => FakeGenerateContentResponse('Today'),
+        );
+
+        final result = await service.classifyTask('title');
+        expect(result, 'Today');
+      });
+
+      test('handles errors', () async {
+        when(() => mockModel.generateContent(any())).thenThrow(Exception('fail'));
+
+        final result = await service.classifyTask('title');
+        expect(result, 'Planned');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting GenerativeModel and content override in `GeminiService`
- add `mocktail` dev dependency for testing
- create `gemini_service_test.dart` covering JSON parsing and error handling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a7ec1b8c88333879dc6e65c002d2b